### PR TITLE
When disabling proxy, also disable proxy auto configuration

### DIFF
--- a/bin/psproxy.sh
+++ b/bin/psproxy.sh
@@ -38,6 +38,7 @@ elif [ $1 == "off" ]; then
   get State:/Network/Service/net.pulsesecure.pulse.nc.main/Proxies
   d.add HTTPSEnable 0
   d.add HTTPEnable 0
+  d.add ProxyAutoConfigEnable 0
   set State:/Network/Service/net.pulsesecure.pulse.nc.main/Proxies
   quit
   EOF`


### PR DESCRIPTION
Hi,

I found that when disabling the proxy any automatic proxy configuration was not disabled.

I have updated this to also remove the auto proxy. 

Thanks,
Shaun